### PR TITLE
Update proproAuth hooks and components

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ export default Header;
 
 `proproAuth` is a set of hooks and utilities to manage authentication state and logic.
 
-#### `useProProAuth()`
+#### `useAuth()`
 
-`useProProAuth()` is a React hook that returns an object with the following properties:
+`useAuth()` is a React hook that returns an object with the following properties:
 
 | Name              | Type       | Description                               |
 | ----------------- | ---------- | ----------------------------------------- |
@@ -74,10 +74,10 @@ export default Header;
 
 ```jsx
 import React from "react";
-import { useProProAuth } from "propro-components";
+import { useAuth } from "propro-components";
 
 const Header = ({ afterSignOutUrl }) => {
-  const { user, isAuthenticated, isLoading, signIn, signOut } = useProProAuth();
+  const { user, isAuthenticated, isLoading, signIn, signOut } = useAuth();
 
   return (
     <header>
@@ -94,15 +94,15 @@ const Header = ({ afterSignOutUrl }) => {
 export default Header;
 ```
 
-#### `withProProAuth()`
+#### `withAuth()`
 
-`withProProAuth()` is a higher-order component that injects the `proproAuth` object into a component's props.
+`withAuth()` is a higher-order component that injects the `proproAuth` object into a component's props.
 
 #### Example
 
 ```jsx
 import React from "react";
-import { withProProAuth } from "propro-components";
+import { withAuth } from "propro-components";
 
 const Header = ({ afterSignOutUrl, proproAuth }) => {
   const { user, isAuthenticated, isLoading, signIn, signOut } = proproAuth;

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -5,6 +5,7 @@ import React, {
   useEffect,
   ReactNode,
   useMemo,
+  ReactElement,
 } from "react";
 import { User } from "./interface/User.interface";
 
@@ -18,7 +19,21 @@ interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType>(null!);
 
-export const useAuth = () => useContext(AuthContext);
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+  return context;
+};
+
+export function withAuth<T>(Component: React.ComponentType<T>) {
+  return function WithAuth(props: T): ReactElement {
+    const authContext = useAuth();
+    // Pass the auth context as a prop to the wrapped component
+    return <Component {...props} proproAuth={authContext} />;
+  };
+}
 
 interface AuthProviderProps {
   children: ReactNode;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export { default as ProProUserButton } from "./ProProUserButton";
-export { AuthProvider, useAuth } from "./AuthContext";
+export { AuthProvider, useAuth, withAuth } from "./AuthContext";
 export { default as proproAuth } from "./ProProAuth";


### PR DESCRIPTION
This pull request updates the `proproAuth` hooks and components to use the new `useAuth` hook instead of the deprecated `useProProAuth` hook. It also includes a new `withAuth` higher-order component to inject the `proproAuth` object into a component's props. This ensures that the authentication logic.